### PR TITLE
Use secure URI in Homepage field.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+el-ixir (3.0-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 00:17:31 +0100
+
 el-ixir (3.0-1) unstable; urgency=medium
 
   * Initial release (closes: #889516).

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper (>= 11), fp-compiler
 Standards-Version: 4.1.3
-Homepage: http://github.com/kilobyte/el-ixir
+Homepage: https://github.com/kilobyte/el-ixir
 Vcs-Git: https://github.com/kilobyte/el-ixir -b debian
 Vcs-Browser: https://github.com/kilobyte/el-ixir/tree/debian
 Rules-Requires-Root: no


### PR DESCRIPTION
Use secure URI in Homepage field.

Fixes lintian: homepage-field-uses-insecure-uri
See https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html for more details.
