### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (= 13), fp-compiler
 Standards-Version: 4.6.2
 Homepage: https://github.com/kilobyte/el-ixir
-Vcs-Git: https://github.com/kilobyte/el-ixir -b debian
+Vcs-Git: https://github.com/kilobyte/el-ixir.git -b debian
 Vcs-Browser: https://github.com/kilobyte/el-ixir/tree/debian
 Rules-Requires-Root: no
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,3 +1,3 @@
 ---
-Repository: https://github.com/kilobyte/el-ixir
+Repository: https://github.com/kilobyte/el-ixir.git
 Repository-Browse: https://github.com/kilobyte/el-ixir

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,3 +1,5 @@
 ---
+Bug-Database: https://github.com/kilobyte/el-ixir/issues
+Bug-Submit: https://github.com/kilobyte/el-ixir/issues/new
 Repository: https://github.com/kilobyte/el-ixir.git
 Repository-Browse: https://github.com/kilobyte/el-ixir


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Repository.
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))
* Set upstream metadata fields: Bug-Database, Bug-Submit. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/93070d99-0356-4f45-a00e-457bd494929d/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/93070d99-0356-4f45-a00e-457bd494929d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/93070d99-0356-4f45-a00e-457bd494929d/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/93070d99-0356-4f45-a00e-457bd494929d.